### PR TITLE
[Fix] Fix printf formatting to handle things like post titles with "%" in them

### DIFF
--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -1155,8 +1155,9 @@ class Post_Handler {
 	 */
 	function add_to_log( string $message ): void {
 		printf(
-			"<div class='progress-msg tec-labs-migration-add-on'><span style='color: #334aff;'>[%s] TEC - $message</span></div>",
-			date( "H:i:s" )
+			"<div class='progress-msg tec-labs-migration-add-on'><span style='color: #334aff;'>[%s] TEC - %s</span></div>",
+			date( "H:i:s" ),
+			$message
 		);
 		flush();
 	}


### PR DESCRIPTION
Imports were failing because some of our posts have the "%" character in them (e.g., "Take 50% Off")

This fixes `printf()` to handle these correctly.