### PR TITLE
Support for the Series post type and recurring events

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/wpai-add-on/
  * GitHub Plugin URI: https://github.com/mt-support/tec-labs-wpai-add-on
  * Description:       WP All Import add-on for The Events Calendar. It can handle Events, Venues, and multiple Organizers, RSVPs, RSVP Attendees, Tickets Commerce Tickets, Tickets Commerce Attendees, and Tickets Commerce Orders. The following are NOT supported: Series, Recurring Events, WooCommerce Tickets, WooCommerce Orders, WooCommerce Attendees.
- * Version:           1.1.0
+ * Version:           1.2.0-dev
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971
  * License:           GPL version 3 or any later version

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/wpai-add-on/
  * GitHub Plugin URI: https://github.com/mt-support/tec-labs-wpai-add-on
  * Description:       WP All Import add-on for The Events Calendar. It can handle Events, Venues, and multiple Organizers, RSVPs, RSVP Attendees, Tickets Commerce Tickets, Tickets Commerce Attendees, and Tickets Commerce Orders. The following are NOT supported: Series, Recurring Events, WooCommerce Tickets, WooCommerce Orders, WooCommerce Attendees.
- * Version:           1.2.0-dev
+ * Version:           1.2.0
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971
  * License:           GPL version 3 or any later version

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: theeventscalendar
 Donate link: https://evnt.is/29
 Tags: events, calendar
-Requires at least: 5.8.6
-Tested up to: 6.3.2
+Requires at least: 6.6
+Tested up to: 6.8.1
 Requires PHP: 7.4
 Stable tag: 1.2.0
 License: GPL version 3 or any later version
@@ -39,7 +39,7 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 = [1.2.0] TBD =
 
-* Version - Events Calendar Pro TBD or higher is required for the migration of Series.
+* Version - Events Calendar Pro 7.6.1 or higher is required for the migration of Series.
 * Feature - Add support for Event Series and Recurring Events
 * Fix - Ensure other non-TEC post types can be imported when the extension is active.
 * Deprecated - Deprecated the `tec_labs_wpai_is_post_type_set` filter without replacement.

--- a/readme.txt
+++ b/readme.txt
@@ -37,10 +37,12 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
-= [1.2.0] 2025-05-09 =
+= [1.2.0] TBD =
 
+* Version - Events Calendar Pro TBD or higher is required for the migration of Series.
 * Feature - Add support for Event Series and Recurring Events
 * Fix - Ensure other non-TEC post types can be imported when the extension is active.
+* Deprecated - Deprecated the `tec_labs_wpai_is_post_type_set` filter without replacement.
 
 = [1.1.0] 2024-09-12 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, calendar
 Requires at least: 5.8.6
 Tested up to: 6.3.2
 Requires PHP: 7.4
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -36,6 +36,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.2.0] 2025-05-09 =
+
+* Feature - Add support for Event Series and Recurring Events
 
 = [1.1.0] 2024-09-12 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 = [1.2.0] 2025-05-09 =
 
 * Feature - Add support for Event Series and Recurring Events
+* Fix - Ensure other non-TEC post types can be imported when the extension is active.
 
 = [1.1.0] 2024-09-12 =
 

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -964,10 +964,15 @@ class Post_Handler {
 		$post_ids = explode( ',', $value );
 		// Get the Series post object
 		$series = get_post( $post_id );
-	
+
+		$new_post_ids = array_filter( array_map( function( $post_id ) {
+			$hash = $this->hashit( $post_id );
+			return $this->get_post_id_from_meta( '_tec_events_export_hash', $hash );
+		}, $post_ids ) );
+
 		// Get the relationship class
 		$relationship = new \TEC\Events_Pro\Custom_Tables\V1\Series\Relationship();
-		$relink = $relationship->with_series($series, $post_ids);
+		$relink = $relationship->with_series( $series, $new_post_ids );
 		
 		// Return, maybe empty.
 		// @todo Skip saving this meta.

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -960,17 +960,18 @@ class Post_Handler {
 			return $value;
 		}
 	
-		// Explode the value which are the post IDs
+		// Explode the value which are the post IDs.
 		$post_ids = explode( ',', $value );
 		// Get the Series post object
 		$series = get_post( $post_id );
 
+		// Grab the new post IDs based on the hash.
 		$new_post_ids = array_filter( array_map( function( $post_id ) {
 			$hash = $this->hashit( $post_id );
 			return $this->get_post_id_from_meta( '_tec_events_export_hash', $hash );
 		}, $post_ids ) );
 
-		// Get the relationship class
+		// Get the relationship class and relink the posts.
 		$relationship = new \TEC\Events_Pro\Custom_Tables\V1\Series\Relationship();
 		$relink = $relationship->with_series( $series, $new_post_ids );
 		

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -935,7 +935,21 @@ class Post_Handler {
 		}
 	}
 
-	function relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id ) {
+	/**
+	 * Relinks posts to a series during import.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param mixed  $value              The meta value to be imported
+	 * @param int    $post_id           The ID of the post being imported
+	 * @param string $key               The meta key being processed
+	 * @param mixed  $original_value    The original meta value before processing
+	 * @param array  $existing_meta_keys Existing meta keys for the post
+	 * @param int    $import_id         The ID of the current import
+	 *
+	 * @return string Empty string to prevent meta saving, or original value if conditions not met
+	 */
+	public function relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id ) {
 		// Bail if not series.
 		if ( get_post_type( $post_id ) !== 'tribe_event_series' ) {
 			return $value;

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -640,16 +640,16 @@ class Post_Handler {
 	 * Sample:
 	 *
 	 * $data = [
-	 * 'create_hash'     => true,
-	 * 'origin_meta_key' => '_TCOrderOrigin',
-	 * 'connections'     => [
-	 * 0 => [
-	 * 'multiple'            => false,
-	 * 'record_meta_key'     => '_tec_tc_order_events_in_order',
-	 * 'connection_meta_key' => '_tec_tc_order_events_in_order',  // optional, if different from record_meta_key
-	 * 'linked_post_type'    => 'tribe_events',
-	 * ],
-	 * ],
+	 * 		'create_hash'     => true,
+	 * 		'origin_meta_key' => '_TCOrderOrigin',
+	 * 		'connections'     => [
+	 * 			0 => [
+	 * 				'multiple'            => false,
+	 * 				'record_meta_key'     => '_tec_tc_order_events_in_order',
+	 * 				'connection_meta_key' => '_tec_tc_order_events_in_order',  // optional, if different from record_meta_key
+	 * 				'linked_post_type'    => 'tribe_events',
+	 * 			],
+	 * 		],
 	 * ];
 	 *
 	 * @param array  $data      Data defining the connections and what needs to be updated.
@@ -1049,6 +1049,9 @@ class Post_Handler {
 
 	/**
 	 * Get the post types supported by the extension.
+	 * 
+	 * @since 1.0.0
+	 * @since 1.2.0 Add Series as supported post type.
 	 *
 	 * @param bool $with_connection Whether it is only the post types that require a connection (true) or all post
 	 *                              types (false).
@@ -1071,7 +1074,8 @@ class Post_Handler {
 				$supported_post_types,
 				'tribe_events',
 				'tribe_venue',
-				'tribe_organizer'
+				'tribe_organizer',
+				'tribe_event_series',
 			);
 		}
 

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -935,6 +935,31 @@ class Post_Handler {
 		}
 	}
 
+	function relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id ) {
+		// Bail if not series.
+		if ( get_post_type( $post_id ) !== 'tribe_event_series' ) {
+			return $value;
+		}
+	
+		// Bail if not the correct meta key.
+		if ( $key !== 'posts_in_series' ) {
+			return $value;
+		}
+	
+		// Explode the value which are the post IDs
+		$post_ids = explode( ',', $value );
+		// Get the Series post object
+		$series = get_post( $post_id );
+	
+		// Get the relationship class
+		$relationship = new \TEC\Events_Pro\Custom_Tables\V1\Series\Relationship();
+		$relink = $relationship->with_series($series, $post_ids);
+		
+		// Return, maybe empty.
+		// @todo Skip saving this meta.
+		return "";
+	}
+
 	/**
 	 * Retrieve post ID based on meta key = meta value pair.
 	 *

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -949,19 +949,19 @@ class Post_Handler {
 	 *
 	 * @return string Empty string to prevent meta saving, or original value if conditions not met
 	 */
-	public function relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id ) {
+	public function relink_posts_to_series( $meta_value, $post_id, $meta_key, $original_value, $existing_meta_keys, $import_id ) {
 		// Bail if not series.
 		if ( get_post_type( $post_id ) !== 'tribe_event_series' ) {
-			return $value;
+			return $meta_value;
 		}
 
 		// Bail if not the correct meta key.
-		if ( $key !== 'posts_in_series' ) {
-			return $value;
+		if ( $meta_key !== 'posts_in_series' ) {
+			return $meta_value;
 		}
 
 		// Explode the value which are the post IDs.
-		$post_ids = explode( ',', $value );
+		$post_ids = explode( ',', $meta_value );
 		// Get the Series post object
 		$series = get_post( $post_id );
 

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -976,9 +976,18 @@ class Post_Handler {
 		}, $post_ids ) );
 
 		$this->add_to_log( "Relinking posts to the Series..." );
+		
 		// Get the relationship class and relink the posts.
 		$relationship = new \TEC\Events_Pro\Custom_Tables\V1\Series\Relationship();
 		$relationship->with_series( $series, $new_post_ids );
+
+		// Clean the post cache for the new posts.
+		foreach ( $new_post_ids as $new_post_id ) {
+			clean_post_cache( $new_post_id );
+		}
+
+		// Clean the post cache for the Series.
+		clean_post_cache( $post_id );
 
 		// We return an empty string to prevent meta saving.
 		return '';

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -135,6 +135,7 @@ class Post_Handler {
 			 * A filter to allow forcing the import even if post type is not supported or not set.
 			 *
 			 * @since 1.1.0
+			 * @since 1.2.0 Deprecated without replacement.
 			 *
 			 * @param bool $continue Whether the import should be forced to continue. Default: false.
 			 */

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -142,7 +142,7 @@ class Post_Handler {
 			 */
 			$continue = apply_filters( 'tec_labs_wpai_is_post_type_set', false );
 
-			$msg .= $continue ? '`tec_labs_wpai_is_post_type_set` override in place, post will be imported.' : 'Skipping.' ;
+			$msg .= $continue ? '`tec_labs_wpai_is_post_type_set` override in place, post will be imported.' : 'Skipping.';
 			$this->add_to_log( $msg );
 
 			// Bail, if there is no override for the non-supported post type.
@@ -158,7 +158,7 @@ class Post_Handler {
 			 *
 			 * @param string $default_post_type The post type to be used when there is none set in the source.
 			 */
-			$data['posttype'] = apply_filters('tec_labs_wpai_default_post_type', $data['posttype'] ?? 'wpai_post' );
+			$data['posttype'] = apply_filters( 'tec_labs_wpai_default_post_type', $data['posttype'] ?? 'wpai_post' );
 		}
 
 		// Bail if data is not valid.
@@ -370,7 +370,7 @@ class Post_Handler {
 		$hash_meta_key = '_' . $link['linked_post_type'] . '_export_hash';
 
 		// Check if meta key exists.
-		if ( ! isset ( $data[ $link['meta_key'] ] ) ) {
+		if ( ! isset( $data[ $link['meta_key'] ] ) ) {
 			$this->add_to_log(
 			// Translators: 1) Title of the post being imported.
 				sprintf(
@@ -493,7 +493,7 @@ class Post_Handler {
 	 */
 	function maybe_update_post( int $post_id, $xml_node, bool $is_update ): void {
 		// Convert SimpleXml object to array for easier use.
-		$record = json_decode( json_encode( ( array ) $xml_node ), 1 );
+		$record = json_decode( json_encode( (array) $xml_node ), 1 );
 
 		// Grab the post type of the post being imported.
 		$post_type = get_post_type( $post_id );
@@ -640,16 +640,16 @@ class Post_Handler {
 	 * Sample:
 	 *
 	 * $data = [
-	 * 		'create_hash'     => true,
-	 * 		'origin_meta_key' => '_TCOrderOrigin',
-	 * 		'connections'     => [
-	 * 			0 => [
-	 * 				'multiple'            => false,
-	 * 				'record_meta_key'     => '_tec_tc_order_events_in_order',
-	 * 				'connection_meta_key' => '_tec_tc_order_events_in_order',  // optional, if different from record_meta_key
-	 * 				'linked_post_type'    => 'tribe_events',
-	 * 			],
-	 * 		],
+	 *        'create_hash'     => true,
+	 *        'origin_meta_key' => '_TCOrderOrigin',
+	 *        'connections'     => [
+	 *            0 => [
+	 *                'multiple'            => false,
+	 *                'record_meta_key'     => '_tec_tc_order_events_in_order',
+	 *                'connection_meta_key' => '_tec_tc_order_events_in_order',  // optional, if different from record_meta_key
+	 *                'linked_post_type'    => 'tribe_events',
+	 *            ],
+	 *        ],
 	 * ];
 	 *
 	 * @param array  $data      Data defining the connections and what needs to be updated.
@@ -678,7 +678,7 @@ class Post_Handler {
 		}
 
 		// 3. Update all the links between the post types.
-		if ( ! empty ( $data['connections'] ) ) {
+		if ( ! empty( $data['connections'] ) ) {
 
 			foreach ( $data['connections'] as $connection ) {
 				$this->update_post_type_connections( $connection, $record, $post_id, $post_title, $post_type );
@@ -745,7 +745,7 @@ class Post_Handler {
 
 		// If the given meta key has a value in the record, and it is a string, do it.
 		if (
-			! empty ( $record[ $record_meta_key ] )
+			! empty( $record[ $record_meta_key ] )
 			&& is_string( $record[ $record_meta_key ] )
 		) {
 			// If there are multiple connections, e.g. more organizers for an event.
@@ -757,7 +757,7 @@ class Post_Handler {
 					$record[ $record_meta_key ] = $id;
 					$update_successful          = $this->update_linked_post_meta(
 						$connection['linked_post_type'],
-						! empty ( $connection['connection_meta_key'] ) ? $connection['connection_meta_key'] : $record_meta_key,
+						! empty( $connection['connection_meta_key'] ) ? $connection['connection_meta_key'] : $record_meta_key,
 						$post_id,
 						$record,
 						$multiple
@@ -941,11 +941,11 @@ class Post_Handler {
 	 * @since 1.2.0
 	 *
 	 * @param mixed  $value              The meta value to be imported
-	 * @param int    $post_id           The ID of the post being imported
-	 * @param string $key               The meta key being processed
-	 * @param mixed  $original_value    The original meta value before processing
+	 * @param int    $post_id            The ID of the post being imported
+	 * @param string $key                The meta key being processed
+	 * @param mixed  $original_value     The original meta value before processing
 	 * @param array  $existing_meta_keys Existing meta keys for the post
-	 * @param int    $import_id         The ID of the current import
+	 * @param int    $import_id          The ID of the current import
 	 *
 	 * @return string Empty string to prevent meta saving, or original value if conditions not met
 	 */
@@ -954,27 +954,31 @@ class Post_Handler {
 		if ( get_post_type( $post_id ) !== 'tribe_event_series' ) {
 			return $value;
 		}
-	
+
 		// Bail if not the correct meta key.
 		if ( $key !== 'posts_in_series' ) {
 			return $value;
 		}
-	
+
 		// Explode the value which are the post IDs.
 		$post_ids = explode( ',', $value );
 		// Get the Series post object
 		$series = get_post( $post_id );
 
+		$this->add_to_log( "Fetching new post IDs for the Series..." );
+
 		// Grab the new post IDs based on the hash.
-		$new_post_ids = array_filter( array_map( function( $post_id ) {
+		$new_post_ids = array_filter( array_map( function ( $post_id ) {
 			$hash = $this->hashit( $post_id );
+
 			return $this->get_post_id_from_meta( '_tribe_events_export_hash', $hash );
 		}, $post_ids ) );
 
+		$this->add_to_log( "Relinking posts to the Series..." );
 		// Get the relationship class and relink the posts.
 		$relationship = new \TEC\Events_Pro\Custom_Tables\V1\Series\Relationship();
-		$relink = $relationship->with_series( $series, $new_post_ids );
-		
+		$relationship->with_series( $series, $new_post_ids );
+
 		// We return an empty string to prevent meta saving.
 		return '';
 	}
@@ -1093,7 +1097,7 @@ class Post_Handler {
 
 	/**
 	 * Get the post types supported by the extension.
-	 * 
+	 *
 	 * @since 1.0.0
 	 * @since 1.2.0 Add Series as supported post type.
 	 *
@@ -1203,15 +1207,16 @@ class Post_Handler {
 	 *
 	 * Allows filtering the list of meta keys that, when modified, should trigger an update to the custom tables’ data.
 	 *
-	 * @since 1.0.0
+	 * @since   1.0.0
+	 *
+	 * @see     https://docs.theeventscalendar.com/reference/hooks/tec_events_custom_tables_v1_tracked_meta_keys/
+	 *
+	 * @see     \TEC\Events\Custom_Tables\V1\Updates\Meta_Watcher::get_tracked_meta_keys()
 	 *
 	 * @param array $tracked_keys Array of the tracked keys.
 	 *
 	 * @return array
 	 *
-	 * @see     https://docs.theeventscalendar.com/reference/hooks/tec_events_custom_tables_v1_tracked_meta_keys/
-	 *
-	 * @see     \TEC\Events\Custom_Tables\V1\Updates\Meta_Watcher::get_tracked_meta_keys()
 	 */
 	public function modify_tracked_meta_keys( array $tracked_keys ): array {
 		$tracked_keys[] = '_EventOrigin';

--- a/src/TEC/Import/Post_Handler.php
+++ b/src/TEC/Import/Post_Handler.php
@@ -968,16 +968,15 @@ class Post_Handler {
 		// Grab the new post IDs based on the hash.
 		$new_post_ids = array_filter( array_map( function( $post_id ) {
 			$hash = $this->hashit( $post_id );
-			return $this->get_post_id_from_meta( '_tec_events_export_hash', $hash );
+			return $this->get_post_id_from_meta( '_tribe_events_export_hash', $hash );
 		}, $post_ids ) );
 
 		// Get the relationship class and relink the posts.
 		$relationship = new \TEC\Events_Pro\Custom_Tables\V1\Series\Relationship();
 		$relink = $relationship->with_series( $series, $new_post_ids );
 		
-		// Return, maybe empty.
-		// @todo Skip saving this meta.
-		return "";
+		// We return an empty string to prevent meta saving.
+		return '';
 	}
 
 	/**

--- a/src/TEC/Plugin.php
+++ b/src/TEC/Plugin.php
@@ -149,8 +149,8 @@ class Plugin extends Service_Provider {
 	public function init_label_hooks() {
 		if ( isset( $_GET['page'] ) &&
 		     (
-				$_GET['page'] == 'pmxe-admin-export'
-				|| $_GET['page'] == 'pmxi-admin-import'
+			     $_GET['page'] == 'pmxe-admin-export'
+			     || $_GET['page'] == 'pmxi-admin-import'
 		     )
 		) {
 			add_filter( 'tec_tickets_commerce_attendee_post_type_args', [ $this, 'tc_attendees_label' ] );
@@ -224,7 +224,7 @@ class Plugin extends Service_Provider {
 	public function relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id ) {
 		return $this->container->make( Post_Handler::class )->relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id );
 	}
-	
+
 	/**
 	 * Adjust the label for Tickets Commerce Attendees to reflect eCommerce provider.
 	 *
@@ -284,15 +284,16 @@ class Plugin extends Service_Provider {
 	 *
 	 * Allows filtering the list of meta keys that, when modified, should trigger an update to the custom tables’ data.
 	 *
-	 * @since 1.0.0
+	 * @since   1.0.0
+	 *
+	 * @see     https://docs.theeventscalendar.com/reference/hooks/tec_events_custom_tables_v1_tracked_meta_keys/
+	 *
+	 * @see     \TEC\Events\Custom_Tables\V1\Updates\Meta_Watcher::get_tracked_meta_keys()
 	 *
 	 * @param array $tracked_keys Array of the tracked keys.
 	 *
 	 * @return array
 	 *
-	 * @see     https://docs.theeventscalendar.com/reference/hooks/tec_events_custom_tables_v1_tracked_meta_keys/
-	 *
-	 * @see     \TEC\Events\Custom_Tables\V1\Updates\Meta_Watcher::get_tracked_meta_keys()
 	 */
 	public function modify_tracked_meta_keys( array $tracked_keys ): array {
 		return $this->container->make( Post_Handler::class )->modify_tracked_meta_keys( $tracked_keys );

--- a/src/TEC/Plugin.php
+++ b/src/TEC/Plugin.php
@@ -221,8 +221,27 @@ class Plugin extends Service_Provider {
 		$this->container->make( Post_Handler::class )->maybe_update_post( $post_id, $xml_node, $is_update );
 	}
 
-	public function relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id ) {
-		return $this->container->make( Post_Handler::class )->relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id );
+	/**
+	 * Relinks posts to series during import.
+	 *
+	 * This filter is called by WP All Import when importing post meta values. It allows modifying
+	 * the meta value before it is saved.
+	 * 
+	 * @since 1.2.0
+	 *
+	 * @see https://www.wpallimport.com/documentation/filter-reference/#pmxi_custom_field
+	 *
+	 * @param mixed  $value              The meta value to be imported
+	 * @param int    $post_id            The ID of the post being imported
+	 * @param string $key                The meta key being imported
+	 * @param mixed  $original_value     The original meta value before any modifications
+	 * @param array  $existing_meta_keys Array of existing meta keys
+	 * @param int    $import_id          The ID of the current import
+	 *
+	 * @return mixed The modified meta value
+	 */
+	public function relink_posts_to_series( $meta_value, $post_id, $meta_key, $original_value, $existing_meta_keys, $import_id ) {
+		return $this->container->make( Post_Handler::class )->relink_posts_to_series( $meta_value, $post_id, $meta_key, $original_value, $existing_meta_keys, $import_id );
 	}
 
 	/**

--- a/src/TEC/Plugin.php
+++ b/src/TEC/Plugin.php
@@ -27,7 +27,7 @@ class Plugin extends Service_Provider {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.1.0';
+	const VERSION = '1.2.0';
 
 	/**
 	 * @since 1.0.0

--- a/src/TEC/Plugin.php
+++ b/src/TEC/Plugin.php
@@ -136,7 +136,7 @@ class Plugin extends Service_Provider {
 		add_filter( 'wp_all_import_is_post_to_create', [ $this, 'maybe_create_post' ], 10, 3 );
 		add_action( 'pmxi_update_post_meta', [ $this, 'maybe_skip_post_meta' ], 10, 3 );
 		add_action( 'pmxi_saved_post', [ $this, 'maybe_update_post' ], 10, 3 );
-
+		add_filter( 'pmxi_custom_field', [ $this, 'relink_posts_to_series' ], 10, 6 );
 		// Clean ourselves up after hooks.
 		remove_action( 'pmxi_before_post_import', [ $this, 'init_import_hooks' ] );
 	}
@@ -221,6 +221,10 @@ class Plugin extends Service_Provider {
 		$this->container->make( Post_Handler::class )->maybe_update_post( $post_id, $xml_node, $is_update );
 	}
 
+	public function relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id ) {
+		return $this->container->make( Post_Handler::class )->relink_posts_to_series( $value, $post_id, $key, $original_value, $existing_meta_keys, $import_id );
+	}
+	
 	/**
 	 * Adjust the label for Tickets Commerce Attendees to reflect eCommerce provider.
 	 *


### PR DESCRIPTION
This PR adds support for the `tribe_event_series` post type, so recurring events and event serieses can be properly migrated from 1 site to another.

[Walkthrough video](https://docs.google.com/videos/d/1NUY0PxwF4UIwj06nS1yJ-0DTpFo1vSsJWKOTYJI6gF0/edit?usp=sharing) (6:24)